### PR TITLE
fix: a11y contrast for dynamic route colors aross theme modes.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7579,7 +7579,6 @@
     },
     "node_modules/colord": {
       "version": "2.9.3",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/colorette": {
@@ -13683,6 +13682,22 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/react-color-a11y": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/react-color-a11y/-/react-color-a11y-1.1.5.tgz",
+      "integrity": "sha512-7G5gHRWeQpTYYWWsKMUmShsLjV7sYuJ7otwFUpLtReR5qfUhaEmXYvX6jkBCPdiZkYUcUiSPwZ4FywDGadKTdg==",
+      "dependencies": {
+        "colord": "^2.9.3",
+        "prop-types": "^15.8.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "react": ">=17.0.0",
+        "react-dom": ">=17.0.0"
+      }
+    },
     "node_modules/react-colorful": {
       "version": "5.6.1",
       "dev": true,
@@ -16804,6 +16819,7 @@
         "leaflet": "^1.9.4",
         "lodash.debounce": "^4.0.8",
         "react": "^18.2.0",
+        "react-color-a11y": "^1.1.5",
         "react-dom": "^18.2.0",
         "react-router-dom": "^6.18.0",
         "styled-components": "^5.3.11"

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -49,6 +49,7 @@
     "leaflet": "^1.9.4",
     "lodash.debounce": "^4.0.8",
     "react": "^18.2.0",
+    "react-color-a11y": "^1.1.5",
     "react-dom": "^18.2.0",
     "react-router-dom": "^6.18.0",
     "styled-components": "^5.3.11"

--- a/packages/ui/src/home.tsx
+++ b/packages/ui/src/home.tsx
@@ -114,9 +114,7 @@ const Home: FC<HomeProps> = () => {
       if (!vehicles.filter(({ predictable }) => predictable).length) {
         toast({
           type: 'info',
-          message: `No ${vehicles.length ? 'predictable ' : ''}vehicles on route.`,
-          // Keep open until the user closes
-          timeout: undefined
+          message: `No ${vehicles.length ? 'predictable ' : ''}vehicles on route.`
         })
       }
     }

--- a/packages/ui/src/modules/favorites/components/favorites.tsx
+++ b/packages/ui/src/modules/favorites/components/favorites.tsx
@@ -89,6 +89,9 @@ const RouteSection = styled.section<{ routeColor: string; routeTextColor: string
     margin: 0;
     padding: 2px 3px;
     line-height: 1;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
     color: ${({ routeTextColor }) => routeTextColor};
     background: ${({ routeColor }) => routeColor};
   }
@@ -270,7 +273,7 @@ const Favorites = memo(function Favorites() {
                         key={routeTitle}
                         routeColor={color}
                         routeTextColor={textColor}>
-                        <h4>{routeTitle}</h4>
+                        <h4 title={routeTitle}>{routeTitle}</h4>
                         {agencyRouteGroup[agencyTitle][routeTitle].map((fav, idx) => {
                           const isHomeStopFav =
                             fav.agency.id === homeStop?.params.agency &&

--- a/packages/ui/vite.config.ts
+++ b/packages/ui/vite.config.ts
@@ -18,7 +18,8 @@ export default defineConfig(() => {
       rollupOptions: {
         output: {
           manualChunks: {
-            leaflet: ['leaflet']
+            leaflet: ['leaflet'],
+            react: ['react', 'react-dom']
           }
         }
       }


### PR DESCRIPTION
Note, addition of `react-color-a11y` brought in more extra KB than I would have liked (I think around 20), also does not dynamically update when switching themes. Consider whether you want to keep this, roll your own, or contribute to the project to get the features I want.

* Restyles the favorites grouping by not grouping stops within the same route under one route title, but rather duplicate the route title for each favorited stop.