### PR TITLE
fix: session creation, add rolling on window visibility.

### DIFF
--- a/packages/api/src/common.ts
+++ b/packages/api/src/common.ts
@@ -1,3 +1,3 @@
 const oneHourMs = 3_600_000
 
-export const SESSION_DURATION_MS = 12 * oneHourMs
+export const SESSION_DURATION_MS = 3 * oneHourMs

--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -21,7 +21,7 @@ const sess: SessionOptions = {
   name: 'busmap.sid',
   secret: env.BM_COOKIE_SECRET as SessionOptions['secret'],
   resave: false,
-  saveUninitialized: true,
+  saveUninitialized: false,
   unset: 'destroy',
   cookie: {
     maxAge: SESSION_DURATION_MS,
@@ -41,9 +41,8 @@ if (env.BM_SESSION_STORE === 'redis') {
     await client.connect()
     /**
      * TTL for the redis session key is derived from `cookie.maxAge` (SESSION_DURATION_MS).
-     * Setting `disableTouch` to `true` prevents rolling sessions
-     * (separate from express-session's `rolling` option which is `false`) while
-     * using connect-redis which updates the underlying TTL when touched.
+     * Setting `disableTouch` to `true` prevents rolling backend sessions (connect-redis updates the TTL).
+     * This is separate from express-session's `rolling` option which controls the client's cookie lifetime.
      *
      * The goal is to keep the client cookie, and redis session expiration synchronized.
      */

--- a/packages/api/src/routes/authn.ts
+++ b/packages/api/src/routes/authn.ts
@@ -7,5 +7,6 @@ const authn = Router()
 authn.post('/login', json(), handler.login)
 authn.post('/logout', json(), handler.logout)
 authn.get('/status', handler.status)
+authn.put('/touch', handler.touch)
 
 export { authn }

--- a/packages/api/src/session.d.ts
+++ b/packages/api/src/session.d.ts
@@ -7,6 +7,8 @@ interface SessionUser {
   givenName: string
   familyName: string
   fullName: string
+  expires?: string | null | Date
+  maxAge?: number | null
 }
 
 declare module 'express-session' {

--- a/packages/ui/src/api/authn.ts
+++ b/packages/ui/src/api/authn.ts
@@ -25,5 +25,16 @@ const logout = async () => {
 
   return result
 }
+const touch = async () => {
+  const result = await transport.fetch<{
+    success: boolean
+    touched: boolean
+    user: User | null
+  }>('/authn/touch', {
+    method: 'PUT'
+  })
 
-export { login, status, logout }
+  return result
+}
+
+export { login, status, logout, touch }

--- a/packages/ui/src/components/signIn.tsx
+++ b/packages/ui/src/components/signIn.tsx
@@ -29,6 +29,7 @@ const SignIn: FC = () => {
         type: 'standard',
         click_listener: () => {
           // TODO: Sign in UX
+          // Show a spinner, blah blah, move to home
         }
       })
     }

--- a/packages/ui/src/root.tsx
+++ b/packages/ui/src/root.tsx
@@ -3,7 +3,7 @@ import { Outlet } from 'react-router-dom'
 import { Toaster } from '@busmap/components/toast'
 
 import { authn } from './channels.js'
-import { status as getStatus } from './api/authn.js'
+import { status } from './api/authn.js'
 import { Layout } from './layout.js'
 import { Providers } from './providers.js'
 import { Navigation } from './components/navigation.js'
@@ -11,13 +11,13 @@ import { Navigation } from './components/navigation.js'
 import type { Status } from './types.js'
 
 const Root = () => {
-  const [status, setStatus] = useState<Status>()
+  const [authStatus, setAuthStatus] = useState<Status>()
 
   useEffect(() => {
     const fetchStatus = async () => {
-      const status = await getStatus()
+      const statusResults = await status()
 
-      setStatus(status)
+      setAuthStatus(statusResults)
     }
 
     fetchStatus()
@@ -36,7 +36,7 @@ const Root = () => {
     <StrictMode>
       <Providers>
         <Toaster anchor="top right" />
-        <Navigation status={status} />
+        <Navigation status={authStatus} />
         <Layout>
           <Outlet />
         </Layout>


### PR DESCRIPTION
Use shorter TTL for sessions and require session initialization before saving to store, i.e. `saveUnitialized` is `false`.
Closes #107 